### PR TITLE
Remove references.fossa.io from search engines

### DIFF
--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Originally discussed in https://teamfossa.slack.com/archives/C79HWQP9D/p1644001201720519

references.fossa.io has not been maintained for quite a while, and we suggest all our customers use https://app.swaggerhub.com/apis-docs/FOSSA1/App as an API reference. Although we do not reference references.fossa.io from the FOSSA application or documentation, some customers still manage to find it through search engines. This change should prevent search engine crawlers from indexing this page and it will eventually go away from search results.

This repository should also be made private to discourage customers from finding it. If we do decide to maintain this documentation again, these changes can be easily reverted.

Tested by running the docs site manually and verifying that `/robots.txt` is correctly served.